### PR TITLE
Add OAuth2 authentication for Google Calender

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,10 @@ dependencies {
   compile('commons-httpclient:commons-httpclient:3.1') {transitive = false}
   compile('org.apache.commons:commons-lang3:3.4') {transitive = false}
   compile('commons-logging:commons-logging:1.2') {transitive = false}
-  compile('com.google.api-client:google-api-client:1.21.0') {transitive = false}
-  compile('com.google.api-client:google-api-client-gson:1.21.0') {transitive = false}
-  compile('com.google.apis:google-api-services-calendar:v3-rev167-1.21.0') {transitive = false}
+  compile('com.google.api-client:google-api-client:1.22.0') {transitive = false}
+  compile('com.google.api-client:google-api-client-gson:1.22.0') {transitive = false}
+  compile('com.google.oauth-client:google-oauth-client-jetty:1.22.0') {transitive = false}
+  compile('com.google.apis:google-api-services-calendar:v3-rev208-1.22.0') {transitive = false}
   compile('com.google.http-client:google-http-client:1.21.0') {transitive = false}
   compile('com.google.http-client:google-http-client-gson:1.21.0') {transitive = false}
   compile('com.google.http-client:google-http-client-jackson2:1.21.0') {transitive = false}

--- a/src/main/java/com/cybozu/GGsync.java
+++ b/src/main/java/com/cybozu/GGsync.java
@@ -38,7 +38,7 @@ import com.cybozu.garoon3.schedule.RepeatInfo;
 import com.cybozu.garoon3.schedule.Span;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 
-
+import com.cybozu.GoogleCalendar.CredentialConfig.AuthType;
 
 public class GGsync {
 	private static final String GGSYNC_TABLE_NAME = "ggsync";
@@ -89,8 +89,11 @@ public class GGsync {
 
 
 
+			String googleAuthType = ggsyncProperties.getGoogleOauthType();
 			String googleOauthMail = ggsyncProperties.getGoogleOauthMail();
 			String googleOauthP12key = ggsyncProperties.getGoogleOauthP12key();
+			String googleCredentialFile = ggsyncProperties.getGoogleOauthCredentialFile();
+			String googleCredentialStoreDir = ggsyncProperties.getGoogleOauthStoreDir();
 			String googleCalendarId = ggsyncProperties.getGoogleCalendarId();
 			String googleCalendarNormalColor = ggsyncProperties.getGoogleCalendarNormalColor();
 			String googleCalendarBannerColor = ggsyncProperties.getGoogleCalendarBannerColor();
@@ -103,8 +106,11 @@ public class GGsync {
 			Date syncEndDateUtc = ggsyncProperties.getSyncEndDateUtc();
 			Integer garoonMemberLimit = ggsyncProperties.getGaroonMemberLimit();
 
+			LOGGER.debug("グーグルカレンダーの認証方式: " + googleAuthType);
 			LOGGER.debug("サービスアカウントのメールアドレス: " + googleOauthMail);
 			LOGGER.debug("サービスアカウントのP12キーファイルの絶対パス: " + googleOauthP12key);
+			LOGGER.debug("OAuth2のclient_idファイルの絶対パス: " + googleCredentialFile);
+			LOGGER.debug("OAuth2の認証情報保存先の絶対パス: " + googleCredentialStoreDir);
 			LOGGER.debug("グーグルカレンダーID: " + googleCalendarId);
 			LOGGER.debug("グーグルカレンダーに登録する通常予定の色: " + googleCalendarNormalColor);
 			LOGGER.debug("グーグルカレンダーに登録する期間予定の色: " + googleCalendarBannerColor);
@@ -114,6 +120,13 @@ public class GGsync {
 			LOGGER.debug("SYNC対象の開始時間: " + syncStartDate);
 			LOGGER.debug("SYNC対象の終了時間: " + syncEndDate);
 
+			GoogleCalendar.CredentialConfig config =
+					new GoogleCalendar.CredentialConfig();
+			config.setAuthType(AuthType.valueOf(googleAuthType));
+			config.setMail(googleOauthMail);
+			config.setP12key(googleOauthP12key);
+			config.setCredentialFile(googleCredentialFile);
+			config.setCredentialStoreDir(googleCredentialStoreDir);
 
 
 			/** SQLiteの利用設定 **/
@@ -135,7 +148,7 @@ public class GGsync {
 			/** ガルーンから削除されたスケジュールをグーグルカレンダーからも削除するために利用 **/
 			ArrayList<Integer> garoonScheduleIdList = new ArrayList<Integer>();
 
-			GoogleCalendar googleCalendar = new GoogleCalendar(googleOauthMail, googleOauthP12key);
+			GoogleCalendar googleCalendar = new GoogleCalendar(config);
 			googleCalendar.setCalendarName(googleCalendarId);
 
 

--- a/src/main/java/com/cybozu/GGsyncProperties.java
+++ b/src/main/java/com/cybozu/GGsyncProperties.java
@@ -7,7 +7,9 @@ import java.util.Date;
 import java.util.Properties;
 
 public class GGsyncProperties {
-	private String GOOGLE_OAUTH_MAIL, GOOGLE_OAUTH_P12KEY, GOOGLE_CALENDAR_ID;
+	private String GOOGLE_OAUTH_TYPE, GOOGLE_CALENDAR_ID;
+	private String GOOGLE_OAUTH_MAIL, GOOGLE_OAUTH_P12KEY;
+	private String GOOGLE_OAUTH_CREDENTIAL_FILE, GOOGLE_OAUTH_STORE_DIR;
 	private String GOOGLE_CALENDAR_NORMAL_COLOR, GOOGLE_CALENDAR_BANNER_COLOR;
 	private String GAROON_URL, GAROON_ACCOUNT, GAROON_PASSWORD;
 	private String EXECUTION_LEVEL;
@@ -23,8 +25,14 @@ public class GGsyncProperties {
 			FileInputStream fis = new FileInputStream(file);
 			prop.load(new InputStreamReader(fis, "UTF-8"));
 
+			this.GOOGLE_OAUTH_TYPE = prop.getProperty("google.oauth.type", "").trim();
+			if (this.GOOGLE_OAUTH_TYPE.isEmpty()) {
+				this.GOOGLE_OAUTH_TYPE = GoogleCalendar.CredentialConfig.AuthType.P12KEY.name();
+			}
 			this.GOOGLE_OAUTH_MAIL = prop.getProperty("google.oauth.mail").trim();
 			this.GOOGLE_OAUTH_P12KEY = prop.getProperty("google.oauth.p12key").trim();
+			this.GOOGLE_OAUTH_CREDENTIAL_FILE = prop.getProperty("google.oauth.credential.file", "").trim();
+			this.GOOGLE_OAUTH_STORE_DIR = prop.getProperty("google.oauth.credential.storedir", "").trim();
 			this.GOOGLE_CALENDAR_ID = prop.getProperty("google.calendar.id").trim();
 			this.GOOGLE_CALENDAR_NORMAL_COLOR = prop.getProperty("google.calendar.normal.color", "5").trim();
 			this.GOOGLE_CALENDAR_BANNER_COLOR = prop.getProperty("google.calendar.banner.color", "7").trim();
@@ -54,12 +62,24 @@ public class GGsyncProperties {
 		}
 	}
 
+	public String getGoogleOauthType() {
+		return GOOGLE_OAUTH_TYPE;
+	}
+
 	public String getGoogleOauthMail() {
 		return this.GOOGLE_OAUTH_MAIL;
 	}
 
 	public String getGoogleOauthP12key() {
 		return this.GOOGLE_OAUTH_P12KEY;
+	}
+
+	public String getGoogleOauthCredentialFile() {
+		return GOOGLE_OAUTH_CREDENTIAL_FILE;
+	}
+
+	public String getGoogleOauthStoreDir() {
+		return GOOGLE_OAUTH_STORE_DIR;
 	}
 
 	public String getGoogleCalendarId() {

--- a/src/main/resources/GGsync.properties
+++ b/src/main/resources/GGsync.properties
@@ -1,3 +1,15 @@
+# Google Callender APIの認証方式
+#   P12KEY : サービスアカウントの秘密鍵(p12key)を使う方式
+#   OAUTH2 : OAuth 2.0 クライアント IDを使う方式
+google.oauth.type=
+
+# カレンダーID
+# 例）xxxxxxxxxxxxxxxxxxxxxxxxxx@group.calendar.google.com
+google.calendar.id=
+
+
+# p12key 設定
+
 # メールアドレス（サービスアカウントのメールアドレス）
 # 例）xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@developer.gserviceaccount.com
 google.oauth.mail=
@@ -6,9 +18,16 @@ google.oauth.mail=
 # 例）C:/GGsync/API Project-xxxxxxxxxxxx.p12
 google.oauth.p12key=
 
-# カレンダーID
-# 例）xxxxxxxxxxxxxxxxxxxxxxxxxx@group.calendar.google.com
-google.calendar.id=
+
+# OAuth2 設定
+
+# OAuth2 の client_id.jsonファイルパス
+# 例) /path/to/client_id.json
+google.oauth.credential.file=
+
+# OAuth2 の認証情報を保存するディレクトリ
+# 例) /path/to/credentials
+google.oauth.credential.storedir=
 
 
 


### PR DESCRIPTION
Google Appsを企業内でドメイン制限しているとサービスアカウント方式ではGoogle Calendarへアクセスできなかったため、OAuth 2.0 クライアントを使う方法を追加しました。

実装方法は以下を参考にしています。
https://developers.google.com/google-apps/calendar/quickstart/java
1. Google でプロジェクトを作成する
2. [API Manager]の[認証情報]画面を開く
   - https://console.developers.google.com/apis/credentials
3. [認証情報を作成]プルダウンから「OAuth クライアントID」を選択
4. 開いた「クライアント ID の作成」画面で[アプリケーションの種類]で[その他]を選択
5. [名前]を任意に入力する （例: GGsync）
6. [認証情報]画面に戻ったら、認証一覧から先ほど作成した項目を探し、その行の右端のダウンロードボタン([JSONをダウンロード])からclient_id.jsonファイルをダウンロードする
7. Google Calenderにて同期対象のカレンダーを作成する
   - この時、カレンダーの共有設定は不要
8. GGsync.properties の設定で以下を設定する
   - google.oauth.type=OAUTH2
   - google.oauth.credential.file=ダウンロードしたclient_id.jsonファイルのパス
   - google.oauth.credential.storedir=認証情報を保存するディレクトリのパス
9. GGsyncを初回実行する。するとブラウザが立ち上がってGoogle Calendarへのアクセス許可の確認が求められるので許可する
   - このときの認証情報が`google.oauth.credential.storedir`で指定したパスに保存され、２回目以降の実行時に利用されます
   - ここで承認できれば、２回目以降は確認なしで実行されます
